### PR TITLE
Update EPRI_flux.mo

### DIFF
--- a/TRANSFORM/HeatAndMassTransfer/ClosureRelations/HeatTransfer/Functions/TwoPhase/CHF/EPRI_flux.mo
+++ b/TRANSFORM/HeatAndMassTransfer/ClosureRelations/HeatTransfer/Functions/TwoPhase/CHF/EPRI_flux.mo
@@ -25,8 +25,14 @@ protected
   // Nonuniform effect correction factor
   Real Y = q_avg/max(0.0001,q_flux);
   Real F_nu = if nu then 1 + (1-Y)/(1+G_en) else 0;
-algorithm
-  CHF :=(A*F_A - x_th_in)/(C*F_g*F_C*F_nu + (x_th - x_th_in)/max(0.0001,q_flux))/(3.169983306e-4) "[BTU/ft^2-hr] to [kW/m^2]";
+ Real B,H,D;
+algorithm 
+  B:=C*F_g*F_C*F_nu;
+  H:=(x_th - x_th_in);
+  D:=max(0.0001, q_flux); //Allows for a solve when flux is zero during startup or times of no heat transfer. 
+  CHF :=((A*F_A - x_th_in)/(B + H/D))/3.169983306e-7; //(3.169983306e-4) "[BTU/ft^2-hr] to [W/m^2]";
+
+
   annotation (Documentation(info="<html>
 <p>Prediction of the critical heat flux using the EPRI correlation as presented in 1982 EPRI Parametric Study of CHF Data Vol. 1-3</p>
 <p><br>      &quot;Outputs&quot;</p>


### PR DESCRIPTION
This method allows for a smoothing of the function during times of low heat flux and during initialization routines. Additionally, it allows the user the ability to see which areas of the CHF correlation are driving the solve if issues arise.