### PR TITLE
Remove invalid use of attribute value

### DIFF
--- a/TRANSFORM/Fluid/Machines/Pump_PressureBooster.mo
+++ b/TRANSFORM/Fluid/Machines/Pump_PressureBooster.mo
@@ -16,7 +16,7 @@ model Pump_PressureBooster
                                    redeclare package Medium = Medium, m_flow(
         max=if allowFlowReversal then +Modelica.Constants.inf else 0))
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealInput in_p(value=p_internal)
+  Modelica.Blocks.Interfaces.RealInput in_p = p_internal
                                              if use_input annotation (Placement(
         transformation(
         origin={0,80},

--- a/TRANSFORM/Fluid/Machines/Pump_SimpleMassFlow.mo
+++ b/TRANSFORM/Fluid/Machines/Pump_SimpleMassFlow.mo
@@ -14,7 +14,7 @@ model Pump_SimpleMassFlow "Prescribes mass flow rate across the component"
   Interfaces.FluidPort_Flow port_b(redeclare package Medium = Medium, m_flow(
         max=if allowFlowReversal then +Modelica.Constants.inf else 0))
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  Modelica.Blocks.Interfaces.RealInput in_m_flow(value=m_flow_internal)
+  Modelica.Blocks.Interfaces.RealInput in_m_flow = m_flow_internal
                                              if use_input annotation (
       Placement(transformation(
         origin={0,80},

--- a/TRANSFORM/Utilities/Visualizers/DynamicGraph.mo
+++ b/TRANSFORM/Utilities/Visualizers/DynamicGraph.mo
@@ -29,7 +29,7 @@ model DynamicGraph "Dynamic graphical display of one variable"
   parameter SI.Time tau=0.01
     "Stabilizing time constant, = 0 then no stabilization"
     annotation (Dialog(group="Numerics"));
-  Modelica.Blocks.Interfaces.RealInput u(value=u_aux) if use_port
+  Modelica.Blocks.Interfaces.RealInput u = u_aux if use_port
     "Input signal" annotation (Placement(transformation(extent={{-70,30},{-30,70}}),
         iconTransformation(extent={{-42,44},{-30,56}})));
 protected


### PR DESCRIPTION
Using `value` as an attribute is invalid Modelica, this pull request replaces these cases with a declaration equation.