### PR TITLE
Change to using a formatted text string instead of a component reference

### DIFF
--- a/TRANSFORM/Utilities/Visualizers/displayReal.mo
+++ b/TRANSFORM/Utilities/Visualizers/displayReal.mo
@@ -30,7 +30,7 @@ equation
         Text(
           extent={{110,36},{260,-32}},
           textColor={0,0,0},
-          textString=unitLabel,
+          textString="%{unitLabel}",
           horizontalAlignment=TextAlignment.Left)}),
     Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,
             100}})));


### PR DESCRIPTION
This should make it more compatible across different tools, since it seems unclear whether a component reference is allowed for this attribute.